### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ $ pip3 install -upgrade pip
 $ pip3 install rospkg catkin_pkg empy
 $ pip3 install tensorflow
 $ pip3 install opencv-python
+$ pip3 install cython
 $ echo "export TF_CPP_MIN_LOG_LEVEL=2" >> ~/.bashrc
 
 #poly2triのインストール ※よりよい方法求む


### PR DESCRIPTION
```
$ python3 setup.py build_ext -i
Traceback (most recent call last):
  File "setup.py", line 4, in <module>
    import Cython
ModuleNotFoundError: No module named 'Cython'
```
といううエラーがでました