### PR TITLE
fix README

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -73,7 +73,7 @@
   <exec_depend>hrpsys_choreonoid_tutorials</exec_depend>
   <exec_depend>msl_hand_models</exec_depend>
   <exec_depend>msl_hand_controller</exec_depend>
-
+  <exec_depend>jsk_path_planner</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
```
$ roslaunch jsk_path_planner recognize_terrain.launch simulation:=true                                              [69/69]
RLException: [recognize_terrain.launch] is neither a launch file in package [jsk_path_planner] nor is [jsk_path_planner] a launch file name
The traceback for the exception was written to the log file
```
というエラーが出ました