### PR TITLE
fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ package.xmlを書くのをサボっていたので、多少抜けが有るかも
 #各種インストール
 $ sudo apt install python3-pip python3
 $ pip3 install -upgrade pip
-$ pip3 install rospkg catkin_pkg empy
+$ pip3 install rospkg catkin_pkg empy numpy-quaternion
 $ pip3 install tensorflow
 $ pip3 install opencv-python
 $ echo "export TF_CPP_MIN_LOG_LEVEL=2" >> ~/.bashrc


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/hiraoka/hiraoka_ws/shimpei_vision_ws/src/terrain_recognition/scripts/accumulated_steppable_region_publisher.py", line 14, in <module>
    import quaternion
ModuleNotFoundError: No module named 'quaternion'
[accumulated_steppable_region_publisher-1] process has died [pid 114047, exit code 1, cmd /home/hiraoka/hiraoka_ws/shimpei_vision_ws/src/terrain_recognition/scripts/accumulated_steppable_region_publisher.py __name:=accumulated_steppable_region_publisher __log:=/home/hiraoka/.ros/log/04e30700-c3ae-11ed-9e5f-e04f43e6c865/accumulated_steppable_region_publisher-1.log].
log file: /home/hiraoka/.ros/log/04e30700-c3ae-11ed-9e5f-e04f43e6c865/accumulated_steppable_region_publisher-1*.log
```
というエラーがでました